### PR TITLE
fix: align wikilink parsing with Obsidian behavior

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,16 @@ src/
 - `erasableSyntaxOnly` is enabled — no parameter properties in constructors (use field declarations)
 - No `baseUrl`/`paths` in tsconfig — use relative imports only
 
+## Documentation
+
+User-facing docs live in a separate repo: `../Gleaner-Docs` (remote: `git@github.com:ChenNima/Gleaner-Docs.git`).
+
+- Every feature doc has both English (`.md`) and Chinese (`.zh.md`) versions
+- Each file starts with a language switcher: `[中文](./Foo.zh.md) | **English**`
+- When adding or updating features, update the corresponding docs in both languages
+- Docs use real `[[wikilink]]` syntax where appropriate (not just code blocks) so they also serve as integration tests
+- After editing, commit and `git push origin main` so Gleaner can sync the changes
+
 ## Auth
 
 - PAT (Personal Access Token) is optional — stored in IndexedDB

--- a/src/components/MarkdownViewer.tsx
+++ b/src/components/MarkdownViewer.tsx
@@ -21,6 +21,7 @@ import { MdLink } from './markdown/MdLink';
 import { RepoVideo } from './markdown/RepoVideo';
 import { FrontmatterCard } from './markdown/FrontmatterCard';
 import { extractFrontmatter } from '../lib/frontmatter';
+import { headingToSlug } from '../lib/wikilink-parser';
 
 // Matches [[target#heading|alias]], all parts optional except the brackets
 const WIKILINK_REGEX = /\[\[([^\]|#]*?)(?:#([^\]|]*?))?(?:\|([^\]]+))?\]\]/g;
@@ -75,8 +76,7 @@ export function MarkdownViewer({ file, loading, resolvedLinks, onWikilinkClick, 
   const fileDir = file?.path.includes('/') ? file.path.substring(0, file.path.lastIndexOf('/')) : '';
 
   const handleAnchorClick = useCallback((id: string) => {
-    // rehype-slug generates kebab-case ids from heading text
-    const slug = id.toLowerCase().replace(/\s+/g, '-').replace(/[^\w-]/g, '');
+    const slug = headingToSlug(id);
     const el = containerRef.current?.querySelector(`[id="${CSS.escape(slug)}"]`)
       ?? containerRef.current?.querySelector(`[id="${CSS.escape(id)}"]`)
       ?? containerRef.current?.querySelector(`[id="${CSS.escape(id.toLowerCase())}"]`);

--- a/src/components/MarkdownViewer.tsx
+++ b/src/components/MarkdownViewer.tsx
@@ -22,13 +22,14 @@ import { RepoVideo } from './markdown/RepoVideo';
 import { FrontmatterCard } from './markdown/FrontmatterCard';
 import { extractFrontmatter } from '../lib/frontmatter';
 
-const WIKILINK_REGEX = /\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g;
+// Matches [[target#heading|alias]], all parts optional except the brackets
+const WIKILINK_REGEX = /\[\[([^\]|#]*?)(?:#([^\]|]*?))?(?:\|([^\]]+))?\]\]/g;
 
 interface MarkdownViewerProps {
   file: MdFile | null;
   loading?: boolean;
   resolvedLinks?: Map<string, boolean>;
-  onWikilinkClick?: (target: string) => void;
+  onWikilinkClick?: (target: string, heading?: string) => void;
   onInternalLinkClick?: (repoPath: string) => void;
   onFolderClick?: (repoPath: string) => void;
   repoFullName?: string;
@@ -47,11 +48,16 @@ function preprocessWikilinks(content: string, resolvedLinks?: Map<string, boolea
   });
 
   // Replace wikilinks in the safe string
-  safe = safe.replace(WIKILINK_REGEX, (_match, target: string, alias?: string) => {
-    const display = alias ?? target;
-    const encoded = encodeURIComponent(target.trim());
-    const isResolved = resolvedLinks?.get(target.trim().toLowerCase()) ?? false;
-    return `<a class="wikilink" data-wikilink="${encoded}" data-resolved="${isResolved}">${display}</a>`;
+  safe = safe.replace(WIKILINK_REGEX, (_match, rawTarget?: string, rawHeading?: string, alias?: string) => {
+    const target = (rawTarget ?? '').trim();
+    const heading = (rawHeading ?? '').trim();
+    // Display: alias > "target#heading" > "#heading" > target
+    const display = alias ?? (target && heading ? `${target}#${heading}` : heading ? `#${heading}` : target);
+    if (!target && !heading) return _match; // [[]] — leave as-is
+    const encodedTarget = encodeURIComponent(target);
+    const encodedHeading = encodeURIComponent(heading);
+    const isResolved = target ? (resolvedLinks?.get(target.toLowerCase()) ?? false) : true; // [[#heading]] is always "resolved" (same file)
+    return `<a class="wikilink" data-wikilink="${encodedTarget}" data-heading="${encodedHeading}" data-resolved="${isResolved}">${display}</a>`;
   });
 
   // Restore code blocks
@@ -69,7 +75,10 @@ export function MarkdownViewer({ file, loading, resolvedLinks, onWikilinkClick, 
   const fileDir = file?.path.includes('/') ? file.path.substring(0, file.path.lastIndexOf('/')) : '';
 
   const handleAnchorClick = useCallback((id: string) => {
-    const el = containerRef.current?.querySelector(`[id="${CSS.escape(id)}"]`)
+    // rehype-slug generates kebab-case ids from heading text
+    const slug = id.toLowerCase().replace(/\s+/g, '-').replace(/[^\w-]/g, '');
+    const el = containerRef.current?.querySelector(`[id="${CSS.escape(slug)}"]`)
+      ?? containerRef.current?.querySelector(`[id="${CSS.escape(id)}"]`)
       ?? containerRef.current?.querySelector(`[id="${CSS.escape(id.toLowerCase())}"]`);
     if (el) el.scrollIntoView({ behavior: 'smooth' });
   }, []);

--- a/src/components/markdown/MdLink.tsx
+++ b/src/components/markdown/MdLink.tsx
@@ -7,8 +7,9 @@ interface MdLinkProps {
   className?: string;
   children?: ReactNode;
   'data-wikilink'?: string;
+  'data-heading'?: string;
   'data-resolved'?: string;
-  onWikilinkClick?: (target: string) => void;
+  onWikilinkClick?: (target: string, heading?: string) => void;
   onInternalLinkClick?: (repoPath: string) => void;
   onFolderClick?: (repoPath: string) => void;
   onAnchorClick?: (id: string) => void;
@@ -64,6 +65,7 @@ export function MdLink({
   className,
   children,
   'data-wikilink': dataWikilink,
+  'data-heading': dataHeading,
   'data-resolved': dataResolved,
   onWikilinkClick,
   onInternalLinkClick,
@@ -72,19 +74,27 @@ export function MdLink({
   fileDir,
   ...rest
 }: MdLinkProps) {
-  // Wikilink
-  if (dataWikilink != null) {
-    const target = decodeURIComponent(dataWikilink);
+  // Wikilink (includes [[target]], [[target#heading]], [[#heading]])
+  if (dataWikilink != null || dataHeading != null) {
+    const target = dataWikilink ? decodeURIComponent(dataWikilink) : '';
+    const heading = dataHeading ? decodeURIComponent(dataHeading) : '';
+    const tipText = target && heading ? `${target}#${heading}` : heading ? `#${heading}` : target;
     const handleClick = (e: MouseEvent) => {
       e.preventDefault();
-      onWikilinkClick?.(target);
+      if (!target && heading) {
+        // [[#heading]] — same-file anchor jump
+        onAnchorClick?.(heading);
+      } else {
+        onWikilinkClick?.(target, heading || undefined);
+      }
     };
     return (
-      <LinkTooltip icon={<FileText className="h-3 w-3 shrink-0" />} tip={target}>
+      <LinkTooltip icon={<FileText className="h-3 w-3 shrink-0" />} tip={tipText}>
         <a
           href="#"
           className={className ?? 'wikilink'}
           data-wikilink={dataWikilink}
+          data-heading={dataHeading}
           data-resolved={dataResolved}
           onClick={handleClick}
           {...rest}

--- a/src/index.css
+++ b/src/index.css
@@ -124,7 +124,7 @@ button, [role="button"], label[class*="cursor-pointer"], a { cursor: pointer; }
   .prose {
     --tw-prose-body: hsl(var(--foreground)) !important;
     --tw-prose-headings: hsl(var(--foreground)) !important;
-    --tw-prose-links: hsl(var(--primary)) !important;
+    --tw-prose-links: hsl(var(--foreground)) !important;
     --tw-prose-bold: hsl(var(--foreground)) !important;
     --tw-prose-code: hsl(var(--foreground)) !important;
     --tw-prose-counters: hsl(var(--muted-foreground)) !important;
@@ -137,17 +137,15 @@ button, [role="button"], label[class*="cursor-pointer"], a { cursor: pointer; }
   }
 
   .wikilink {
-    color: hsl(var(--primary));
-    text-decoration: underline;
-    text-decoration-style: dotted;
+    text-decoration-style: dotted !important;
     cursor: pointer;
   }
   .wikilink:hover {
-    text-decoration-style: solid;
+    text-decoration-style: solid !important;
   }
   .wikilink[data-resolved="false"] {
-    color: hsl(var(--muted-foreground));
-    text-decoration-style: dashed;
+    color: hsl(var(--muted-foreground)) !important;
+    text-decoration-style: dashed !important;
   }
 
   /* Let highlight.js theme control code block appearance */

--- a/src/lib/hydrate.ts
+++ b/src/lib/hydrate.ts
@@ -38,7 +38,7 @@ export async function hydrateStoreFromDB(): Promise<void> {
   }
 
   // Check if links need re-parsing (e.g. parser was updated)
-  const PARSER_VERSION = '2';
+  const PARSER_VERSION = '3';
   const allFiles = await db.files.toArray();
   const filesWithContent = allFiles.filter((f) => f.content !== null);
   const linkCount = await db.links.count();

--- a/src/lib/wikilink-parser.ts
+++ b/src/lib/wikilink-parser.ts
@@ -193,15 +193,93 @@ export async function parseAndStoreLinks(file: MdFile): Promise<void> {
 }
 
 /**
+ * Pre-built index for O(1) wikilink resolution.
+ */
+interface FileIndex {
+  fileIdSet: Set<string>;
+  /** lowercase filename (without .md) → files */
+  nameMap: Map<string, MdFile[]>;
+  /** lowercase frontmatter title → files */
+  titleMap: Map<string, MdFile[]>;
+  /** lowercase path suffix (without .md) → files, e.g. "getting-started/quick start" */
+  pathSuffixMap: Map<string, MdFile[]>;
+}
+
+function buildFileIndex(allFiles: MdFile[]): FileIndex {
+  const fileIdSet = new Set(allFiles.map((f) => f.id));
+  const nameMap = new Map<string, MdFile[]>();
+  const titleMap = new Map<string, MdFile[]>();
+  const pathSuffixMap = new Map<string, MdFile[]>();
+
+  for (const file of allFiles) {
+    // Index by filename
+    const fileName = stripMdExtension(file.path.split('/').pop() ?? '').toLowerCase();
+    pushToMap(nameMap, fileName, file);
+
+    // Index by frontmatter title
+    if (file.title) {
+      pushToMap(titleMap, file.title.toLowerCase(), file);
+    }
+
+    // Index by all path suffixes for path-based matching
+    const normalized = stripMdExtension(file.path).toLowerCase();
+    const parts = normalized.split('/');
+    // Full path and every suffix with at least one directory component
+    for (let i = 0; i < parts.length; i++) {
+      pushToMap(pathSuffixMap, parts.slice(i).join('/'), file);
+    }
+  }
+
+  return { fileIdSet, nameMap, titleMap, pathSuffixMap };
+}
+
+function pushToMap(map: Map<string, MdFile[]>, key: string, file: MdFile): void {
+  const arr = map.get(key);
+  if (arr) arr.push(file);
+  else map.set(key, [file]);
+}
+
+/**
+ * Look up a wikilink target using a pre-built index. O(1) per lookup.
+ */
+function findMatchingFileIndexed(
+  index: FileIndex,
+  rawTarget: string,
+  sourceRepo: string | null,
+): MdFile | null {
+  const target = stripMdExtension(rawTarget).toLowerCase();
+  if (!target) return null;
+
+  let candidates: MdFile[];
+
+  if (target.includes('/')) {
+    candidates = index.pathSuffixMap.get(target) ?? [];
+  } else {
+    // Merge name + title matches, dedupe
+    const byName = index.nameMap.get(target) ?? [];
+    const byTitle = index.titleMap.get(target) ?? [];
+    if (byTitle.length === 0) {
+      candidates = byName;
+    } else if (byName.length === 0) {
+      candidates = byTitle;
+    } else {
+      const seen = new Set<string>();
+      candidates = [];
+      for (const f of byName) { seen.add(f.id); candidates.push(f); }
+      for (const f of byTitle) { if (!seen.has(f.id)) candidates.push(f); }
+    }
+  }
+
+  return pickBestCandidate(candidates, sourceRepo);
+}
+
+/**
  * Resolve all unresolved wikilinks globally.
- * Strategy matches resolveWikilink:
- * 1. Strip .md from target, then match by filename and frontmatter title
- * 2. Support path-suffix matching when target contains /
- * 3. Prefer same repo, then shortest path
+ * Builds an index first for O(N+M) total instead of O(N×M).
  */
 export async function resolveAllLinks(): Promise<void> {
   const allFiles = await db.files.toArray();
-  const fileIdSet = new Set(allFiles.map((f) => f.id));
+  const index = buildFileIndex(allFiles);
 
   const allLinks = await db.links.toArray();
 
@@ -211,14 +289,14 @@ export async function resolveAllLinks(): Promise<void> {
 
     // If targetFileId is already set (from standard markdown links), verify it exists
     if (link.targetFileId) {
-      if (!fileIdSet.has(link.targetFileId)) {
+      if (!index.fileIdSet.has(link.targetFileId)) {
         await db.links.update(link.id!, { targetFileId: null });
       }
       continue;
     }
 
     const sourceRepo = link.sourceFileId.split('::')[0];
-    const resolved = findMatchingFile(allFiles, link.targetTitle, sourceRepo);
+    const resolved = findMatchingFileIndexed(index, link.targetTitle, sourceRepo);
 
     if (resolved && link.targetFileId !== resolved.id) {
       await db.links.update(link.id!, { targetFileId: resolved.id });
@@ -295,11 +373,26 @@ export async function resolveWikilink(
 }
 
 /**
- * Core matching logic shared by resolveWikilink and resolveAllLinks.
- *
- * 1. Strip .md from target
- * 2. If target contains '/', do path-suffix match; otherwise match filename + frontmatter title
- * 3. Among candidates: prefer same repo, then shortest path
+ * Among candidates: prefer same repo, then shortest path.
+ */
+function pickBestCandidate(candidates: MdFile[], sourceRepo: string | null): MdFile | null {
+  if (candidates.length === 0) return null;
+  if (candidates.length === 1) return candidates[0];
+
+  if (sourceRepo) {
+    const sameRepo = candidates.filter((f) => f.repoFullName === sourceRepo);
+    if (sameRepo.length === 1) return sameRepo[0];
+    if (sameRepo.length > 1) {
+      return sameRepo.sort((a, b) => a.path.length - b.path.length)[0];
+    }
+  }
+
+  return candidates.sort((a, b) => a.path.length - b.path.length)[0];
+}
+
+/**
+ * Core matching logic for resolveWikilink (single lookup, no pre-built index).
+ * Uses linear scan — fine for one-off calls, use findMatchingFileIndexed for batch.
  */
 function findMatchingFile(
   allFiles: MdFile[],
@@ -309,18 +402,15 @@ function findMatchingFile(
   const target = stripMdExtension(rawTarget).toLowerCase();
   if (!target) return null;
 
-  const hasPath = target.includes('/');
   let candidates: MdFile[];
 
-  if (hasPath) {
-    // Path-suffix match: file.path (without .md) must end with target
+  if (target.includes('/')) {
     const suffix = '/' + target;
     candidates = allFiles.filter((f) => {
       const normalized = stripMdExtension(f.path).toLowerCase();
       return normalized === target || normalized.endsWith(suffix);
     });
   } else {
-    // Match by filename (without .md) OR frontmatter title
     candidates = allFiles.filter((f) => {
       const fileName = stripMdExtension(f.path.split('/').pop() ?? '').toLowerCase();
       if (fileName === target) return true;
@@ -329,19 +419,5 @@ function findMatchingFile(
     });
   }
 
-  if (candidates.length === 0) return null;
-  if (candidates.length === 1) return candidates[0];
-
-  // Prefer same repo
-  if (sourceRepo) {
-    const sameRepo = candidates.filter((f) => f.repoFullName === sourceRepo);
-    if (sameRepo.length === 1) return sameRepo[0];
-    if (sameRepo.length > 1) {
-      // Among same-repo candidates, pick shortest path
-      return sameRepo.sort((a, b) => a.path.length - b.path.length)[0];
-    }
-  }
-
-  // Fallback: shortest path
-  return candidates.sort((a, b) => a.path.length - b.path.length)[0];
+  return pickBestCandidate(candidates, sourceRepo);
 }

--- a/src/lib/wikilink-parser.ts
+++ b/src/lib/wikilink-parser.ts
@@ -2,21 +2,47 @@ import { db, getActiveRepoNames } from '../db';
 import type { WikiLink, MdFile } from '../db';
 import { extractFrontmatter } from './frontmatter';
 
-const WIKILINK_REGEX = /\[\[([^\]|]+)(?:\|[^\]]+)?\]\]/g;
+// Captures: group1=target (file part, may be empty), group2=heading, group3=alias
+const WIKILINK_REGEX = /\[\[([^\]|#]*?)(?:#([^\]|]*?))?(?:\|([^\]]+))?\]\]/g;
 const MD_LINK_REGEX = /\[([^\]]+)\]\(([^)]+\.md(?:#[^)]*)?)\)/g;
 const EXTERNAL_LINK_REGEX = /\[([^\]]*)\]\((https?:\/\/[^)]+)\)/g;
 
+export interface ParsedWikilink {
+  target: string;   // file part only (no #heading), already trimmed
+  heading: string;   // heading part (without #), empty string if none
+  alias: string;     // display text, empty string if none
+}
+
 /**
- * Extract wikilink targets from markdown content
+ * Extract wikilink targets from markdown content.
+ * Returns only the file-name portion (no #heading) for backward compatibility.
  */
 export function extractWikilinks(content: string): string[] {
-  const targets: string[] = [];
+  return extractParsedWikilinks(content).map((w) => w.target).filter(Boolean);
+}
+
+/**
+ * Extract structured wikilink data from markdown content.
+ */
+export function extractParsedWikilinks(content: string): ParsedWikilink[] {
+  const results: ParsedWikilink[] = [];
   let match;
   const re = new RegExp(WIKILINK_REGEX.source, WIKILINK_REGEX.flags);
   while ((match = re.exec(content)) !== null) {
-    targets.push(match[1].trim());
+    results.push({
+      target: (match[1] ?? '').trim(),
+      heading: (match[2] ?? '').trim(),
+      alias: (match[3] ?? '').trim(),
+    });
   }
-  return targets;
+  return results;
+}
+
+/**
+ * Strip .md suffix (case-insensitive) from a wikilink target.
+ */
+function stripMdExtension(name: string): string {
+  return name.replace(/\.md$/i, '');
 }
 
 /**
@@ -112,10 +138,11 @@ export async function parseAndStoreLinks(file: MdFile): Promise<void> {
 
   const links: WikiLink[] = [];
 
-  // Extract wikilinks
-  const wikiTargets = extractWikilinks(file.content);
-  for (const targetTitle of wikiTargets) {
-    links.push({ sourceFileId: file.id, targetTitle, targetFileId: null });
+  // Extract wikilinks — store only the file-name portion as targetTitle
+  const parsed = extractParsedWikilinks(file.content);
+  for (const w of parsed) {
+    if (!w.target) continue; // [[#heading]] only — no file target to store
+    links.push({ sourceFileId: file.id, targetTitle: w.target, targetFileId: null });
   }
 
   // Extract standard markdown links and resolve to file IDs immediately
@@ -160,22 +187,14 @@ export async function parseAndStoreLinks(file: MdFile): Promise<void> {
 
 /**
  * Resolve all unresolved wikilinks globally.
- * Strategy:
- * 1. Exact title match (case-insensitive)
- * 2. Cross-repo global search
- * 3. If multiple matches, prefer same repo
+ * Strategy matches resolveWikilink:
+ * 1. Strip .md from target, then match by filename and frontmatter title
+ * 2. Support path-suffix matching when target contains /
+ * 3. Prefer same repo, then shortest path
  */
 export async function resolveAllLinks(): Promise<void> {
   const allFiles = await db.files.toArray();
   const fileIdSet = new Set(allFiles.map((f) => f.id));
-  const titleMap = new Map<string, MdFile[]>();
-
-  for (const file of allFiles) {
-    const title = fileTitle(file).toLowerCase();
-    const existing = titleMap.get(title) ?? [];
-    existing.push(file);
-    titleMap.set(title, existing);
-  }
 
   const allLinks = await db.links.toArray();
 
@@ -191,20 +210,10 @@ export async function resolveAllLinks(): Promise<void> {
       continue;
     }
 
-    // Resolve by title (for wikilinks)
-    const target = link.targetTitle.toLowerCase();
-    const candidates = titleMap.get(target);
-
-    if (!candidates || candidates.length === 0) {
-      continue;
-    }
-
-    // Prefer same repo
     const sourceRepo = link.sourceFileId.split('::')[0];
-    const sameRepo = candidates.find((f) => f.repoFullName === sourceRepo);
-    const resolved = sameRepo ?? candidates[0];
+    const resolved = findMatchingFile(allFiles, link.targetTitle, sourceRepo);
 
-    if (link.targetFileId !== resolved.id) {
+    if (resolved && link.targetFileId !== resolved.id) {
       await db.links.update(link.id!, { targetFileId: resolved.id });
     }
   }
@@ -267,33 +276,65 @@ export async function getOutgoingLinks(fileId: string): Promise<{ target: MdFile
 }
 
 /**
- * Resolve a single wikilink target to a file ID
+ * Resolve a single wikilink target to a file ID.
+ * Supports: strip .md, path-suffix matching, filename + frontmatter title dual match.
  */
 export async function resolveWikilink(
   targetTitle: string,
   sourceRepoFullName?: string
 ): Promise<MdFile | null> {
   const allFiles = await db.files.toArray();
-  const target = targetTitle.toLowerCase();
-
-  const matches = allFiles.filter(
-    (f) => fileTitle(f).toLowerCase() === target
-  );
-
-  if (matches.length === 0) return null;
-  if (matches.length === 1) return matches[0];
-
-  // Prefer same repo
-  if (sourceRepoFullName) {
-    const sameRepo = matches.find((f) => f.repoFullName === sourceRepoFullName);
-    if (sameRepo) return sameRepo;
-  }
-
-  return matches[0];
+  return findMatchingFile(allFiles, targetTitle, sourceRepoFullName ?? null);
 }
 
-function fileTitle(file: MdFile): string {
-  if (file.title) return file.title;
-  const name = file.path.split('/').pop() ?? file.path;
-  return name.replace(/\.md$/i, '');
+/**
+ * Core matching logic shared by resolveWikilink and resolveAllLinks.
+ *
+ * 1. Strip .md from target
+ * 2. If target contains '/', do path-suffix match; otherwise match filename + frontmatter title
+ * 3. Among candidates: prefer same repo, then shortest path
+ */
+function findMatchingFile(
+  allFiles: MdFile[],
+  rawTarget: string,
+  sourceRepo: string | null,
+): MdFile | null {
+  const target = stripMdExtension(rawTarget).toLowerCase();
+  if (!target) return null;
+
+  const hasPath = target.includes('/');
+  let candidates: MdFile[];
+
+  if (hasPath) {
+    // Path-suffix match: file.path (without .md) must end with target
+    const suffix = '/' + target;
+    candidates = allFiles.filter((f) => {
+      const normalized = stripMdExtension(f.path).toLowerCase();
+      return normalized === target || normalized.endsWith(suffix);
+    });
+  } else {
+    // Match by filename (without .md) OR frontmatter title
+    candidates = allFiles.filter((f) => {
+      const fileName = stripMdExtension(f.path.split('/').pop() ?? '').toLowerCase();
+      if (fileName === target) return true;
+      if (f.title && f.title.toLowerCase() === target) return true;
+      return false;
+    });
+  }
+
+  if (candidates.length === 0) return null;
+  if (candidates.length === 1) return candidates[0];
+
+  // Prefer same repo
+  if (sourceRepo) {
+    const sameRepo = candidates.filter((f) => f.repoFullName === sourceRepo);
+    if (sameRepo.length === 1) return sameRepo[0];
+    if (sameRepo.length > 1) {
+      // Among same-repo candidates, pick shortest path
+      return sameRepo.sort((a, b) => a.path.length - b.path.length)[0];
+    }
+  }
+
+  // Fallback: shortest path
+  return candidates.sort((a, b) => a.path.length - b.path.length)[0];
 }

--- a/src/lib/wikilink-parser.ts
+++ b/src/lib/wikilink-parser.ts
@@ -2,6 +2,13 @@ import { db, getActiveRepoNames } from '../db';
 import type { WikiLink, MdFile } from '../db';
 import { extractFrontmatter } from './frontmatter';
 
+/**
+ * Convert a heading string to a slug matching rehype-slug's output.
+ */
+export function headingToSlug(heading: string): string {
+  return heading.toLowerCase().replace(/\s+/g, '-').replace(/[^\w-]/g, '');
+}
+
 // Captures: group1=target (file part, may be empty), group2=heading, group3=alias
 const WIKILINK_REGEX = /\[\[([^\]|#]*?)(?:#([^\]|]*?))?(?:\|([^\]]+))?\]\]/g;
 const MD_LINK_REGEX = /\[([^\]]+)\]\(([^)]+\.md(?:#[^)]*)?)\)/g;

--- a/src/pages/FilePage.tsx
+++ b/src/pages/FilePage.tsx
@@ -6,7 +6,7 @@ import { DocumentThemePicker } from '../components/DocumentThemePicker';
 import { db } from '../db';
 import type { MdFile } from '../db';
 import { getFileContent } from '../lib/github';
-import { resolveWikilink, extractWikilinks } from '../lib/wikilink-parser';
+import { resolveWikilink, extractWikilinks, headingToSlug } from '../lib/wikilink-parser';
 import { useAppStore } from '../stores/app';
 import { MarkdownViewer } from '../components/MarkdownViewer';
 
@@ -134,7 +134,7 @@ export default function FilePage() {
     if (hash && scrollRef.current) {
       // Heading anchor from wikilink — scroll to it
       requestAnimationFrame(() => {
-        const slug = hash.toLowerCase().replace(/\s+/g, '-').replace(/[^\w-]/g, '');
+        const slug = headingToSlug(hash);
         const el = scrollRef.current?.querySelector(`[id="${CSS.escape(slug)}"]`)
           ?? scrollRef.current?.querySelector(`[id="${CSS.escape(hash)}"]`);
         if (el) el.scrollIntoView({ behavior: 'smooth' });

--- a/src/pages/FilePage.tsx
+++ b/src/pages/FilePage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback, useRef } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { ChevronLeft, ChevronRight, ChevronRightIcon } from 'lucide-react';
 import { DocumentThemePicker } from '../components/DocumentThemePicker';
@@ -16,6 +16,7 @@ const scrollMemory = new Map<string, number>();
 export default function FilePage() {
   const { owner, name, '*': filePath } = useParams();
   const navigate = useNavigate();
+  const location = useLocation();
   const { t } = useTranslation();
   const setCurrentFileId = useAppStore((s) => s.setCurrentFileId);
   const syncVersion = useAppStore((s) => s.syncVersion);
@@ -73,11 +74,12 @@ export default function FilePage() {
     return () => setCurrentFileId(null);
   }, [fileId, owner, name, filePath, syncVersion]);
 
-  const handleWikilinkClick = async (target: string) => {
+  const handleWikilinkClick = async (target: string, heading?: string) => {
     const resolved = await resolveWikilink(target, repoFullName);
     if (resolved) {
       const [rOwner, rRepo] = resolved.repoFullName.split('/');
-      navigate(`/repo/${rOwner}/${rRepo}/${resolved.path}`);
+      const targetPath = `/repo/${rOwner}/${rRepo}/${resolved.path}`;
+      navigate(heading ? `${targetPath}#${encodeURIComponent(heading)}` : targetPath);
     }
   };
 
@@ -125,17 +127,27 @@ export default function FilePage() {
     };
   }, [fileId]);
 
-  // Restore scroll position after content loads
+  // Restore scroll position after content loads, or scroll to heading hash
   useEffect(() => {
     if (loading || !fileId) return;
-    const saved = scrollMemory.get(fileId);
-    if (saved != null && scrollRef.current) {
-      // Wait a frame for content to render
+    const hash = location.hash ? decodeURIComponent(location.hash.slice(1)) : '';
+    if (hash && scrollRef.current) {
+      // Heading anchor from wikilink — scroll to it
       requestAnimationFrame(() => {
-        scrollRef.current?.scrollTo(0, saved);
+        const slug = hash.toLowerCase().replace(/\s+/g, '-').replace(/[^\w-]/g, '');
+        const el = scrollRef.current?.querySelector(`[id="${CSS.escape(slug)}"]`)
+          ?? scrollRef.current?.querySelector(`[id="${CSS.escape(hash)}"]`);
+        if (el) el.scrollIntoView({ behavior: 'smooth' });
       });
+    } else {
+      const saved = scrollMemory.get(fileId);
+      if (saved != null && scrollRef.current) {
+        requestAnimationFrame(() => {
+          scrollRef.current?.scrollTo(0, saved);
+        });
+      }
     }
-  }, [loading, fileId]);
+  }, [loading, fileId, location.hash]);
 
   // Build breadcrumb segments: [repo label, ...path parts]
   const pathParts = filePath?.split('/') ?? [];

--- a/src/styles/markdown-themes.css
+++ b/src/styles/markdown-themes.css
@@ -11,11 +11,11 @@
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
 }
 
-.md-theme-github a:not(.wikilink) {
+.md-theme-github a {
   color: #0969da !important;
   text-decoration: underline;
 }
-.dark .md-theme-github a:not(.wikilink) {
+.dark .md-theme-github a {
   color: #58a6ff !important;
 }
 
@@ -51,14 +51,14 @@
   margin-bottom: 0.4em;
 }
 
-.md-theme-obsidian a:not(.wikilink) {
+.md-theme-obsidian a {
   color: #7c3aed !important;
   text-decoration: none;
 }
-.md-theme-obsidian a:not(.wikilink):hover {
+.md-theme-obsidian a:hover {
   text-decoration: underline;
 }
-.dark .md-theme-obsidian a:not(.wikilink) {
+.dark .md-theme-obsidian a {
   color: #a78bfa !important;
 }
 
@@ -124,11 +124,11 @@
   letter-spacing: 0.03em;
 }
 
-.md-theme-academic a:not(.wikilink) {
+.md-theme-academic a {
   color: #1a4d8f !important;
   text-decoration: underline;
 }
-.dark .md-theme-academic a:not(.wikilink) {
+.dark .md-theme-academic a {
   color: #6ba3d6 !important;
 }
 
@@ -206,20 +206,20 @@
   margin-bottom: 0.2em;
 }
 
-.md-theme-notion a:not(.wikilink) {
+.md-theme-notion a {
   color: #2383e2 !important;
   text-decoration: underline;
   text-decoration-color: rgba(35, 131, 226, 0.3);
   text-underline-offset: 2px;
 }
-.md-theme-notion a:not(.wikilink):hover {
+.md-theme-notion a:hover {
   text-decoration-color: #2383e2;
 }
-.dark .md-theme-notion a:not(.wikilink) {
+.dark .md-theme-notion a {
   color: #529cca !important;
   text-decoration-color: rgba(82, 156, 202, 0.3);
 }
-.dark .md-theme-notion a:not(.wikilink):hover {
+.dark .md-theme-notion a:hover {
   text-decoration-color: #529cca;
 }
 
@@ -307,11 +307,11 @@
   font-weight: 600;
 }
 
-.md-theme-newsprint a:not(.wikilink) {
+.md-theme-newsprint a {
   color: #1a5276 !important;
   text-decoration: underline;
 }
-.dark .md-theme-newsprint a:not(.wikilink) {
+.dark .md-theme-newsprint a {
   color: #85c1e9 !important;
 }
 


### PR DESCRIPTION
- Upgrade regex to parse [[target#heading|alias]] format
- Support strip .md: [[XX.md]] and [[XX]] both resolve to same file
- Support path-suffix matching: [[folder/file]] matches by path ending
- Match both filename and frontmatter title for better link resolution
- Add [[file#heading]] cross-file anchor navigation
- Add [[#heading]] same-file anchor scrolling
- Ensure parseAndStoreLinks stores only file part (no #heading) to preserve backlinks and graph integrity
- Unify resolveAllLinks and resolveWikilink via shared findMatchingFile
- Bump parser version to trigger re-parse on existing data